### PR TITLE
feat: add reasoningEffort option for simplified thinking budget control

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This server provides the following MCP tools. Parameter schemas are defined usin
     * `generationConfig` (object) - Controls generation parameters like temperature, topP, etc.
       * `thinkingConfig` (object) - Controls model reasoning process
         * `thinkingBudget` (number) - Maximum tokens for reasoning (0-24576)
+        * `reasoningEffort` (string) - Simplified control: "none" (0 tokens), "low" (1K), "medium" (8K), "high" (24K)
     * `safetySettings` (array) - Controls content filtering by harm category
     * `systemInstruction` (string or object) - System instruction to guide model behavior
     * `cachedContentName` (string) - Identifier for cached content to use with this request
@@ -109,6 +110,7 @@ This server provides the following MCP tools. Parameter schemas are defined usin
     * `generationConfig` (object) - Controls generation parameters like temperature, topP, etc.
       * `thinkingConfig` (object) - Controls model reasoning process
         * `thinkingBudget` (number) - Maximum tokens for reasoning (0-24576)
+        * `reasoningEffort` (string) - Simplified control: "none" (0 tokens), "low" (1K), "medium" (8K), "high" (24K)
     * `safetySettings` (array) - Controls content filtering by harm category
     * `systemInstruction` (string or object) - System instruction to guide model behavior
     * `cachedContentName` (string) - Identifier for cached content to use with this request
@@ -135,6 +137,7 @@ This server provides the following MCP tools. Parameter schemas are defined usin
     * `generationConfig` (object) - Controls generation parameters
       * `thinkingConfig` (object) - Controls model reasoning process
         * `thinkingBudget` (number) - Maximum tokens for reasoning (0-24576)
+        * `reasoningEffort` (string) - Simplified control: "none" (0 tokens), "low" (1K), "medium" (8K), "high" (24K)
     * `safetySettings` (array) - Controls content filtering
     * `systemInstruction` (string or object) - System instruction to guide model behavior
     * `cachedContentName` (string) - Identifier for cached content to use with this session
@@ -145,6 +148,7 @@ This server provides the following MCP tools. Parameter schemas are defined usin
     * `generationConfig` (object) - Controls generation parameters
       * `thinkingConfig` (object) - Controls model reasoning process
         * `thinkingBudget` (number) - Maximum tokens for reasoning (0-24576)
+        * `reasoningEffort` (string) - Simplified control: "none" (0 tokens), "low" (1K), "medium" (8K), "high" (24K)
     * `safetySettings` (array) - Controls content filtering
     * `tools` (array) - Tool definitions including function declarations
     * `toolConfig` (object) - Configures tool behavior
@@ -164,6 +168,7 @@ This server provides the following MCP tools. Parameter schemas are defined usin
     * `generationConfig` (object) - Generation configuration settings to apply to the selected model's response.
       * `thinkingConfig` (object) - Controls model reasoning process
         * `thinkingBudget` (number) - Maximum tokens for reasoning (0-24576)
+        * `reasoningEffort` (string) - Simplified control: "none" (0 tokens), "low" (1K), "medium" (8K), "high" (24K)
     * `safetySettings` (array) - Safety settings to apply to both routing and final response.
     * `systemInstruction` (string or object) - A system instruction to guide the model's behavior after routing.
 
@@ -332,6 +337,28 @@ Here are examples of how an MCP client (like Claude) might call these tools usin
         "maxOutputTokens": 1000,
         "thinkingConfig": {
           "thinkingBudget": 8192
+        }
+      }
+    }
+  </arguments>
+</use_mcp_tool>
+```
+
+**Example 2c: Content Generation with Simplified Reasoning Effort**
+
+```xml
+<use_mcp_tool>
+  <server_name>gemini-server</server_name>
+  <tool_name>gemini_generateContent</tool_name>
+  <arguments>
+    {
+      "modelName": "gemini-1.5-pro",
+      "prompt": "Solve this complex math problem: Find all values of x where 2sin(x) = x^2-x+1 in the range [0, 2π].",
+      "generationConfig": {
+        "temperature": 0.2,
+        "maxOutputTokens": 1000,
+        "thinkingConfig": {
+          "reasoningEffort": "high"
         }
       }
     }

--- a/src/services/gemini/GeminiContentService.ts
+++ b/src/services/gemini/GeminiContentService.ts
@@ -249,6 +249,19 @@ export class GeminiContentService {
       }
     }
     
+    // Map reasoningEffort to thinkingBudget if provided
+    if (requestConfig.thinkingConfig?.reasoningEffort) {
+      const effortMap: Record<string, number> = {
+        "none": 0,
+        "low": 1024, // 1K tokens
+        "medium": 8192, // 8K tokens
+        "high": 24576 // 24K tokens
+      };
+      
+      requestConfig.thinkingConfig.thinkingBudget = effortMap[requestConfig.thinkingConfig.reasoningEffort];
+      logger.debug(`Mapped reasoning effort '${requestConfig.thinkingConfig.reasoningEffort}' to thinking budget: ${requestConfig.thinkingConfig.thinkingBudget} tokens`);
+    }
+    
     // Apply default thinking budget if available and not specified in request
     if (this.defaultThinkingBudget !== undefined && !requestConfig.thinkingConfig) {
       requestConfig.thinkingConfig = {

--- a/src/services/gemini/GeminiValidationSchemas.ts
+++ b/src/services/gemini/GeminiValidationSchemas.ts
@@ -73,6 +73,7 @@ export const DEFAULT_SAFETY_SETTINGS = [
 export const ThinkingConfigSchema = z
   .object({
     thinkingBudget: z.number().int().min(0).max(24576).optional(),
+    reasoningEffort: z.enum(["none", "low", "medium", "high"]).optional(),
   })
   .optional();
 

--- a/src/tools/geminiGenerateContentParams.ts
+++ b/src/tools/geminiGenerateContentParams.ts
@@ -23,6 +23,12 @@ export const thinkingConfigSchema = z
       .describe(
         "Controls the amount of reasoning the model performs. Range: 0-24576. Lower values provide faster responses, higher values improve complex reasoning."
       ),
+    reasoningEffort: z
+      .enum(["none", "low", "medium", "high"])
+      .optional()
+      .describe(
+        "Simplified control over model reasoning. Options: none (0 tokens), low (1K tokens), medium (8K tokens), high (24K tokens)."
+      ),
   })
   .optional()
   .describe("Optional configuration for controlling model reasoning.");

--- a/src/tools/geminiRouteMessageParams.ts
+++ b/src/tools/geminiRouteMessageParams.ts
@@ -42,6 +42,12 @@ const ThinkingConfigSchema = z
       .describe(
         "Controls the amount of reasoning the model performs. Range: 0-24576. Lower values provide faster responses, higher values improve complex reasoning."
       ),
+    reasoningEffort: z
+      .enum(["none", "low", "medium", "high"])
+      .optional()
+      .describe(
+        "Simplified control over model reasoning. Options: none (0 tokens), low (1K tokens), medium (8K tokens), high (24K tokens)."
+      ),
   })
   .optional()
   .describe("Optional configuration for controlling model reasoning.");

--- a/src/tools/geminiSendMessageParams.ts
+++ b/src/tools/geminiSendMessageParams.ts
@@ -43,6 +43,12 @@ const ThinkingConfigSchema = z
       .describe(
         "Controls the amount of reasoning the model performs. Range: 0-24576. Lower values provide faster responses, higher values improve complex reasoning."
       ),
+    reasoningEffort: z
+      .enum(["none", "low", "medium", "high"])
+      .optional()
+      .describe(
+        "Simplified control over model reasoning. Options: none (0 tokens), low (1K tokens), medium (8K tokens), high (24K tokens)."
+      ),
   })
   .optional()
   .describe("Optional configuration for controlling model reasoning.");

--- a/src/tools/geminiStartChatParams.ts
+++ b/src/tools/geminiStartChatParams.ts
@@ -42,6 +42,12 @@ const ThinkingConfigSchema = z
       .describe(
         "Controls the amount of reasoning the model performs. Range: 0-24576. Lower values provide faster responses, higher values improve complex reasoning."
       ),
+    reasoningEffort: z
+      .enum(["none", "low", "medium", "high"])
+      .optional()
+      .describe(
+        "Simplified control over model reasoning. Options: none (0 tokens), low (1K tokens), medium (8K tokens), high (24K tokens)."
+      ),
   })
   .optional()
   .describe("Optional configuration for controlling model reasoning.");

--- a/src/types/googleGenAITypes.ts
+++ b/src/types/googleGenAITypes.ts
@@ -13,6 +13,7 @@ import type {
 // Define ThinkingConfig interface for controlling model reasoning
 interface ThinkingConfig {
   thinkingBudget?: number;
+  reasoningEffort?: "none" | "low" | "medium" | "high";
 }
 
 // Types for params that match the SDK v0.10.0 structure

--- a/tests/unit/services/gemini/GeminiValidationSchemas.test.ts
+++ b/tests/unit/services/gemini/GeminiValidationSchemas.test.ts
@@ -130,6 +130,40 @@ describe("GeminiValidationSchemas", () => {
       assert.strictEqual(result.thinkingBudget, undefined);
     });
     
+    it("should validate valid reasoningEffort values", () => {
+      const validValues = ["none", "low", "medium", "high"];
+      
+      for (const value of validValues) {
+        // Should not throw
+        const result = ThinkingConfigSchema.parse({ reasoningEffort: value });
+        assert.strictEqual(result.reasoningEffort, value);
+      }
+    });
+    
+    it("should throw on invalid reasoningEffort values", () => {
+      assert.throws(
+        () => ThinkingConfigSchema.parse({ reasoningEffort: "invalid" }),
+        (err: unknown) => {
+          assert(err instanceof ZodError);
+          const zodError = err as ZodError;
+          assert.strictEqual(zodError.errors[0].path[0], "reasoningEffort");
+          return true;
+        }
+      );
+    });
+    
+    it("should validate both thinkingBudget and reasoningEffort in same object", () => {
+      const config = {
+        thinkingBudget: 5000,
+        reasoningEffort: "medium"
+      };
+      
+      // Should not throw
+      const result = ThinkingConfigSchema.parse(config);
+      assert.strictEqual(result.thinkingBudget, 5000);
+      assert.strictEqual(result.reasoningEffort, "medium");
+    });
+    
     it("should validate thinking budget at boundaries", () => {
       // Min value (0)
       assert.doesNotThrow(() => 
@@ -189,6 +223,20 @@ describe("GeminiValidationSchemas", () => {
       const result = GenerationConfigSchema.parse(validGenerationConfig);
       assert.strictEqual(result.temperature, 0.7);
       assert.strictEqual(result.thinkingConfig?.thinkingBudget, 5000);
+    });
+    
+    it("should validate reasoningEffort within generation config", () => {
+      const validGenerationConfig = {
+        temperature: 0.7,
+        thinkingConfig: {
+          reasoningEffort: "high"
+        }
+      };
+      
+      // Should not throw
+      const result = GenerationConfigSchema.parse(validGenerationConfig);
+      assert.strictEqual(result.temperature, 0.7);
+      assert.strictEqual(result.thinkingConfig?.reasoningEffort, "high");
     });
     
     it("should throw on invalid thinking budget in generation config", () => {


### PR DESCRIPTION
This enhancement adds a new 'reasoningEffort' option to the thinking budget feature to provide simplified control over
      model reasoning. The following values map to specific token budgets:
      - 'none' → 0 tokens (fast path only)
      - 'low' → 1,024 tokens
      - 'medium' → 8,192 tokens
      - 'high' → 24,576 tokens (maximum reasoning)